### PR TITLE
Added check so only debian wheezy gets added

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,9 +2,13 @@
 
 - name: add dotdeb key
   apt_key: id=89DF5277 url=http://www.dotdeb.org/dotdeb.gpg state=present
+  when: ansible_distribution in ['Debian'] and ansible_distribution_release == "wheezy"
 
 - name: add dotdeb repository
   apt_repository: repo='deb http://mirror.nl.leaseweb.net/dotdeb/ wheezy all' state=present update_cache=no
+  when: ansible_distribution in ['Debian'] and ansible_distribution_release == "wheezy"
 
 - name: add dotdeb source repository
   apt_repository: repo='deb-src http://mirror.nl.leaseweb.net/dotdeb/ wheezy all' state=present update_cache=yes
+  when: ansible_distribution in ['Debian'] and ansible_distribution_release == "wheezy"
+


### PR DESCRIPTION
Since f500.php has a dependency on this role a simple check for debian wheezy will make the other role usable for Ubuntu and other distro's.
